### PR TITLE
move daycount data inside structs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+site/

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,79 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "1df01539a1c952cef21f2d2d1c092c2bcf0177d7"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.6.0"
+
+[[Documenter]]
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "LibGit2", "Logging", "Markdown", "Pkg", "REPL", "Random", "Test", "Unicode"]
+git-tree-sha1 = "a6db1c69925cdc53aafb38caec4446be26e0c617"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.21.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,15 @@
+using Documenter
+using DayCounts
+
+makedocs(
+    sitename = "DayCounts",
+    format = Documenter.HTML(),
+    modules = [DayCounts]
+)
+
+# Documenter can also automatically deploy documentation to gh-pages.
+# See "Hosting Documentation" and deploydocs() in the Documenter manual
+# for more information.
+#=deploydocs(
+    repo = "<repository url>"
+)=#

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,31 +12,31 @@ julia> using DayCounts, Dates
 julia> d1, d2 = Date("2019-01-01"), Date("2019-04-01") # standard year
 (2019-01-01, 2019-04-01)
 
-julia> yearfraction(d1, d2, Thirty360())
+julia> yearfrac(d1, d2, Thirty360())
 0.25
 
-julia> yearfraction(d1, d2, Actual360())
+julia> yearfrac(d1, d2, Actual360())
 0.25
 
-julia> yearfraction(d1, d2, Actual365Fixed())
+julia> yearfrac(d1, d2, Actual365Fixed())
 0.2465753424657534
 
-julia> yearfraction(d1, d2, ActualActualISDA())
+julia> yearfrac(d1, d2, ActualActualISDA())
 0.2465753424657534
 
 julia> d1, d2 = Date("2020-01-01"), Date("2020-04-01") # standard year
 (2020-01-01, 2020-04-01)
 
-julia> yearfraction(d1, d2, Thirty360())
+julia> yearfrac(d1, d2, Thirty360())
 0.25
 
-julia> yearfraction(d1, d2, Actual360())
+julia> yearfrac(d1, d2, Actual360())
 0.25277777777777777
 
-julia> yearfraction(d1, d2, Actual365Fixed())
+julia> yearfrac(d1, d2, Actual365Fixed())
 0.2493150684931507
 
-julia> yearfraction(d1, d2, ActualActualISDA())
+julia> yearfrac(d1, d2, ActualActualISDA())
 0.24863387978142076
 ```
 
@@ -46,7 +46,7 @@ julia> yearfraction(d1, d2, ActualActualISDA())
 
 # Interface
 ```@docs
-yearfraction
+yearfrac
 ```
 
 # [`DayCount` types](@id daycount_types)
@@ -54,6 +54,7 @@ yearfraction
 Actual365Fixed
 Actual360
 ActualActualISDA
+ActualActualICMA
 Thirty360
 ThirtyE360
 ThirtyE360ISDA

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,61 @@
+# DayCounts.jl
+
+DayCounts.jl provides calculations of various day count conventions used in finance for
+computing accrued interest and discount factors. These conventions have arisen to handle
+factors such as months of different lengths and leap days.
+
+# Example
+
+```jldoctest
+julia> using DayCounts, Dates
+
+julia> d1, d2 = Date("2019-01-01"), Date("2019-04-01") # standard year
+(2019-01-01, 2019-04-01)
+
+julia> yearfraction(d1, d2, Thirty360())
+0.25
+
+julia> yearfraction(d1, d2, Actual360())
+0.25
+
+julia> yearfraction(d1, d2, Actual365Fixed())
+0.2465753424657534
+
+julia> yearfraction(d1, d2, ActualActualISDA())
+0.2465753424657534
+
+julia> d1, d2 = Date("2020-01-01"), Date("2020-04-01") # standard year
+(2020-01-01, 2020-04-01)
+
+julia> yearfraction(d1, d2, Thirty360())
+0.25
+
+julia> yearfraction(d1, d2, Actual360())
+0.25277777777777777
+
+julia> yearfraction(d1, d2, Actual365Fixed())
+0.2493150684931507
+
+julia> yearfraction(d1, d2, ActualActualISDA())
+0.24863387978142076
+```
+
+# External Links
+- [_Day count convention_ on Wikipedia](https://en.wikipedia.org/wiki/Day_count_convention)
+- [Nasdaq Day Count Fractions](https://business.nasdaq.com/media/day-count-fractions_tcm5044-53854.pdf)
+
+# Interface
+```@docs
+yearfraction
+```
+
+# [`DayCount` types](@id daycount_types)
+```@docs
+Actual365Fixed
+Actual360
+ActualActualISDA
+Thirty360
+ThirtyE360
+ThirtyE360ISDA
+```
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,31 +12,31 @@ julia> using DayCounts, Dates
 julia> d1, d2 = Date("2019-01-01"), Date("2019-04-01") # standard year
 (2019-01-01, 2019-04-01)
 
-julia> yearfrac(d1, d2, Thirty360())
+julia> yearfrac(d1, d2, DayCounts.Thirty360())
 0.25
 
-julia> yearfrac(d1, d2, Actual360())
+julia> yearfrac(d1, d2, DayCounts.Actual360())
 0.25
 
-julia> yearfrac(d1, d2, Actual365Fixed())
+julia> yearfrac(d1, d2, DayCounts.Actual365Fixed())
 0.2465753424657534
 
-julia> yearfrac(d1, d2, ActualActualISDA())
+julia> yearfrac(d1, d2, DayCounts.ActualActualISDA())
 0.2465753424657534
 
 julia> d1, d2 = Date("2020-01-01"), Date("2020-04-01") # standard year
 (2020-01-01, 2020-04-01)
 
-julia> yearfrac(d1, d2, Thirty360())
+julia> yearfrac(d1, d2, DayCounts.Thirty360())
 0.25
 
-julia> yearfrac(d1, d2, Actual360())
+julia> yearfrac(d1, d2, DayCounts.Actual360())
 0.25277777777777777
 
-julia> yearfrac(d1, d2, Actual365Fixed())
+julia> yearfrac(d1, d2, DayCounts.Actual365Fixed())
 0.2493150684931507
 
-julia> yearfrac(d1, d2, ActualActualISDA())
+julia> yearfrac(d1, d2, DayCounts.ActualActualISDA())
 0.24863387978142076
 ```
 
@@ -51,12 +51,12 @@ yearfrac
 
 # [`DayCount` types](@id daycount_types)
 ```@docs
-Actual365Fixed
-Actual360
-ActualActualISDA
-ActualActualICMA
-Thirty360
-ThirtyE360
-ThirtyE360ISDA
+DayCounts.Actual365Fixed
+DayCounts.Actual360
+DayCounts.ActualActualISDA
+DayCounts.ActualActualICMA
+DayCounts.Thirty360
+DayCounts.ThirtyE360
+DayCounts.ThirtyE360ISDA
 ```
 

--- a/src/DayCounts.jl
+++ b/src/DayCounts.jl
@@ -81,6 +81,9 @@ function yearfraction(startdate::Date, enddate::Date, ::ActualActualISDA)
     end
 end
 
+# helper function
+thirty360(dy,dm,dd) = (360*dy + 30*dm + dd)/360
+
 """
     Thirty360()
     BondBasis()
@@ -95,13 +98,14 @@ const BondBasis = Thirty360
 function yearfraction(startdate::Date, enddate::Date, ::Thirty360)
     dy = year(enddate)-year(startdate)
     dm = month(enddate)-month(startdate)
+    
     d1 = day(startdate)
     d2 = day(enddate)
-    if d1 > 29
+    if d1 >= 30
         d2 = min(d2,30)
+        d1 = 30
     end
-    d1 = min(d1,30)
-    return dy+dm/12+(d2-d1)/360
+    return thirty360(dy,dm,d2-d1)
 end
 
 """
@@ -120,7 +124,7 @@ function yearfraction(startdate::Date, enddate::Date, ::ThirtyE360)
     dm = month(enddate)-month(startdate)
     d1 = min(day(startdate),30)
     d2 = min(day(enddate),30)
-    return dy+dm/12+(d2-d1)/360
+    return thirty360(dy,dm,d2-d1)
 end
 
 """
@@ -142,7 +146,7 @@ function yearfrac(startdate::Date, enddate::Date, dc::ThirtyE360ISDA)
     d2 = day(enddate)
     d1 = d1 == lastdayofmonth(Date(y1,2)) ? 30 : min(d1,30)
     d2 = ((d2 == lastdayofmonth(Date(y1,2))) & (enddate != dc.maturity)) ? 30 : min(d1,30)
-    return y2-y1+dm/12+(d2-d1)/360
+    return thirty360(y2-y1,dm,d2-d1)
 end
 
 end # module

--- a/src/DayCounts.jl
+++ b/src/DayCounts.jl
@@ -5,14 +5,15 @@ module DayCounts
 
 using Dates
 
-export yearfraction, DayCount, Thirty360, ThirtyE360, ThirtyE360ISDA, Actual360, Actual365Fixed, ActualActualISDA
-
+export yearfraction, DayCount,
+    Actual365Fixed, Actual365F, Actual360, ActualActualISDA,
+    Thirty360, BondBasis, ThirtyE360, EurobondBasis, ThirtyE360ISDA
 
 """
     yearfraction(startdate::Date, enddate::Date, dc::DayCount)
 
 Compute the fractional number of years between `startdate` and `enddate`, according to the
-day count convention `dc`.
+[`DayCount` object](@ref daycount_types) `dc`.
 """
 function yearfraction
 end
@@ -24,9 +25,12 @@ abstract type DayCount end
     Actual365Fixed()
     Actual365F()
 
-"Actual/365 (Fixed)" day count convention.
+**Actual/365 (Fixed)** day count convention.
 
-The actual number of days divided by 365.
+The year fraction is computed as:
+```math
+\\frac{\\text{# of days}}{365}
+```
 
 # Reference
  - 2006 ISDA definitions, §4.16 (d)
@@ -40,9 +44,12 @@ end
 """
     Actual360()
 
-"Actual/360" day count convention.
+**Actual/360** day count convention.
 
-Actual number of days divided by 360.
+The year fraction is computed as:
+```math
+\\frac{\\text{# of days}}{360}
+```
 
 # Reference
  - 2006 ISDA definitions, §4.16 (e)
@@ -57,11 +64,15 @@ end
 """
     ActualActualISDA()
 
-"Actual/Actual (ISDA)" day count convention.
+**Actual/Actual (ISDA)** day count convention.
 
-The actual number of days which fall in a standard year divided by 365 plus the actual
-number of days which fall in a leap year divided by 365. The start date is included, and
-the end date is excluded.
+The year fraction is computed as:
+```math
+\\frac{\\text{# of days in standard year}}{365} +
+\\frac{\\text{# of days in leap year}}{366}
+```
+
+For the purposes of above, the start date is included and the end date is excluded.
 
 # Reference
  - 2006 ISDA definitions, §4.16 (b)
@@ -88,7 +99,19 @@ thirty360(dy,dm,dd) = (360*dy + 30*dm + dd)/360
     Thirty360()
     BondBasis()
 
-"30/360" or "Bond Basis" day count convention.
+**30/360** or **Bond Basis** day count convention.
+
+The year fraction is computed as:
+```math
+\\frac{360 \\times (y_2 - y_1) + 30 \\times (m_2 - m_1) + (d_2 - d_1)}{360}
+```
+where
+- ``y_1`` and ``y_2`` are the years of the start and end date, respectively.
+- ``m_1`` and ``m_2`` are the months of the start and end date, respectively.
+- ``d_1`` is the day of the month at the start date, unless it is 31, in which case it is
+  30.
+- ``d_2`` is the day of the month at the end date, unless it is 31 and ``d_1 > 29``, in
+  which case it is 30.
 
 # Reference
  - 2006 ISDA definitions, §4.16 (f)
@@ -98,12 +121,12 @@ const BondBasis = Thirty360
 function yearfraction(startdate::Date, enddate::Date, ::Thirty360)
     dy = year(enddate)-year(startdate)
     dm = month(enddate)-month(startdate)
-    
+
     d1 = day(startdate)
     d2 = day(enddate)
     if d1 >= 30
-        d2 = min(d2,30)
         d1 = 30
+        d2 = min(d2,30)
     end
     return thirty360(dy,dm,d2-d1)
 end
@@ -111,8 +134,20 @@ end
 """
     ThirtyE360()
     EurobondBasis()
-    
-"30E/360" or "Eurobond Basis" day count convention.
+
+**30E/360** or **Eurobond Basis** day count convention.
+
+The year fraction is computed as:
+```math
+\\frac{360 \\times (y_2 - y_1) + 30 \\times (m_2 - m_1) + (d_2 - d_1)}{360}
+```
+where
+- ``y_1`` and ``y_2`` are the years of the start and end date, respectively.
+- ``m_1`` and ``m_2`` are the months of the start and end date, respectively.
+- ``d_1`` is the day of the month at the start date, unless it is 31, in which case it is
+  30.
+- ``d_2`` is the day of the month at the end date, unless it is 31, in which case it is
+  30.
 
 # Reference
  - 2006 ISDA definitions, §4.16 (g)
@@ -129,8 +164,20 @@ end
 
 """
     ThirtyE360ISDA(maturity::Date)
-    
-"30E/360 (ISDA)" day count convention.
+
+**30E/360 (ISDA)** day count convention.
+
+The year fraction is computed as:
+```math
+\\frac{360 \\times (y_2 - y_1) + 30 \\times (m_2 - m_1) + (d_2 - d_1)}{360}
+```
+where
+- ``y_1`` and ``y_2`` are the years of the start and end date, respectively.
+- ``m_1`` and ``m_2`` are the months of the start and end date, respectively.
+- ``d_1`` is the day of the month at the start date, unless it is the last day of
+  February, or 31, in which case it is 30.
+- ``d_2`` is the day of the month at the end date, unless it is the last day of February
+  and not the maturity date, or 31, in which case it is 30.
 
 # Reference
  - 2006 ISDA definitions, §4.16 (h)
@@ -138,15 +185,14 @@ end
 struct ThirtyE360ISDA <: DayCount
     maturity::Date
 end
-function yearfrac(startdate::Date, enddate::Date, dc::ThirtyE360ISDA)
+function yearfraction(startdate::Date, enddate::Date, dc::ThirtyE360ISDA)
     y1 = year(startdate)
     y2 = year(enddate)
-    dm = month(enddate)-month(startdate)
-    d1 = day(startdate)
-    d2 = day(enddate)
-    d1 = d1 == lastdayofmonth(Date(y1,2)) ? 30 : min(d1,30)
-    d2 = ((d2 == lastdayofmonth(Date(y1,2))) & (enddate != dc.maturity)) ? 30 : min(d1,30)
-    return thirty360(y2-y1,dm,d2-d1)
+    m1 = month(startdate)
+    m2 = month(enddate)
+    d1 = startdate == lastdayofmonth(startdate) ? 30 : day(startdate)
+    d2 = enddate == lastdayofmonth(enddate) && !(m2 == 2 && enddate == dc.maturity) ? 30 : day(enddate)
+    return thirty360(y2-y1,m2-m1,d2-d1)
 end
 
 end # module

--- a/src/DayCounts.jl
+++ b/src/DayCounts.jl
@@ -6,9 +6,8 @@ module DayCounts
 using Dates
 
 export yearfrac, DayCount,
-    Actual365Fixed, Actual365F, Actual360, ActualActualISDA,
-    ActualActualICMA, ActualActualISMA, ISMA99,
-    Thirty360, BondBasis, ThirtyE360, EurobondBasis, ThirtyE360ISDA
+    Actual365Fixed, Actual360, ActualActualISDA, ActualActualICMA,
+    Thirty360, ThirtyE360, ThirtyE360ISDA
 
 """
     yearfrac(startdate::Date, enddate::Date, dc::DayCount)
@@ -24,7 +23,6 @@ abstract type DayCount end
 
 """
     Actual365Fixed()
-    Actual365F()
 
 **Actual/365 (Fixed)** day count convention.
 
@@ -96,8 +94,6 @@ end
 
 """
     ActualActualICMA(schedule::StepRange{Date,Month})
-    ActualActualISMA(schedule::StepRange{Date,Month})
-    ISMA99(schedule::StepRange{Date,Month})
 
 **Actual/Actual (ICMA)**, **Actual/Actual (ISMA)** or **ISMA-99** day count convention.
 
@@ -142,7 +138,7 @@ function yearfrac(startdate::Date, enddate::Date, dc::ActualActualICMA)
             return Dates.value(enddate - startdate) / (frequency * Dates.value(dc.schedule[j] - dc.schedule[i]))
         end
     end
-    
+
     f1 = i1 == j1 ? 0.0 : (dc.schedule[j1] - startdate) / (dc.schedule[j1] - dc.schedule[i1])
     f2 = i2 == j2 ? 0.0 : (enddate - dc.schedule[i2]) / (dc.schedule[j2] - dc.schedule[i2])
 
@@ -155,7 +151,6 @@ thirty360(dy,dm,dd) = (360*dy + 30*dm + dd)/360
 
 """
     Thirty360()
-    BondBasis()
 
 **30/360** or **Bond Basis** day count convention.
 
@@ -191,7 +186,6 @@ end
 
 """
     ThirtyE360()
-    EurobondBasis()
 
 **30E/360** or **Eurobond Basis** day count convention.
 

--- a/src/DayCounts.jl
+++ b/src/DayCounts.jl
@@ -4,10 +4,7 @@ module DayCounts
 # https://www.isda.org/2008/12/22/30-360-day-count-conventions/
 
 using Dates
-
-export yearfrac, DayCount,
-    Actual365Fixed, Actual360, ActualActualISDA, ActualActualICMA,
-    Thirty360, ThirtyE360, ThirtyE360ISDA
+export yearfrac
 
 """
     yearfrac(startdate::Date, enddate::Date, dc::DayCount)
@@ -163,7 +160,7 @@ where
 - ``m_1`` and ``m_2`` are the months of the start and end date, respectively.
 - ``d_1`` is the day of the month at the start date, unless it is 31, in which case it is
   30.
-- ``d_2`` is the day of the month at the end date, unless it is 31 and ``d_1 > 29``, in
+- ``d_2`` is the day of the month at the end date, unless it is 31 and ``d_1 ≥ 30``, in
   which case it is 30.
 
 # Reference
@@ -179,7 +176,9 @@ function yearfrac(startdate::Date, enddate::Date, ::Thirty360)
     d2 = day(enddate)
     if d1 >= 30
         d1 = 30
-        d2 = min(d2,30)
+        if d2 >= 30
+            d2 = 30
+        end
     end
     return thirty360(dy,dm,d2-d1)
 end

--- a/src/DayCounts.jl
+++ b/src/DayCounts.jl
@@ -5,7 +5,7 @@ module DayCounts
 
 using Dates
 
-export yearfraction, DayCount, Thirty360, ThirtyE360, ThirtyE360ISDA, Actual360, Actual365, ActualActualISDA
+export yearfraction, DayCount, Thirty360, ThirtyE360, ThirtyE360ISDA, Actual360, Actual365Fixed, ActualActualISDA
 
 
 """
@@ -22,6 +22,7 @@ abstract type DayCount end
 
 """
     Actual365Fixed()
+    Actual365F()
 
 "Actual/365 (Fixed)" day count convention.
 
@@ -31,6 +32,7 @@ The actual number of days divided by 365.
  - 2006 ISDA definitions, §4.16 (d)
 """
 struct Actual365Fixed <: DayCount end
+const Actual365F = Actual365Fixed
 function yearfraction(startdate::Date, enddate::Date, ::Actual365Fixed)
     return Dates.value(enddate-startdate)/365
 end
@@ -72,9 +74,9 @@ function yearfraction(startdate::Date, enddate::Date, ::ActualActualISDA)
         return Dates.value(enddate - startdate) / daysinyear(startdate)
     else
         d1 = daysinyear(startyear)
-        n1 = (d1 - dayofyear(startdate) + 1) / d1
+        n1 = d1 - dayofyear(startdate) + 1
         d2 = daysinyear(endyear)
-        n2 = (dayofyear(enddate) - 1) / d2
+        n2 = dayofyear(enddate) - 1
         return n1/d1 + n2/d2 + (endyear - startyear - 1)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,135 +5,195 @@ using Test
 # https://github.com/OpenGamma/Strata/blob/efaa0be0d08dc61c23692e7b86df101ea0fb7223/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
 @testset "Actual365Fixed" begin
     dc = Actual365Fixed()
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 365
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 365
-    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 365
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == (4 + 366 + 365 + 365 + 365 + 58) / 365
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == (4 + 366 + 365 + 365 + 365 + 59) / 365
-    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == (4 + 366 + 365 + 365 + 365 + 60) / 365
-    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 365
-    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 365
-    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 365
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 365
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 365
+    @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 365
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == (4 + 366 + 365 + 365 + 365 + 58) / 365
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == (4 + 366 + 365 + 365 + 365 + 59) / 365
+    @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == (4 + 366 + 365 + 365 + 365 + 60) / 365
+    @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 365
+    @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 365
+    @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 365
 end
 
 @testset "Actual360" begin
     dc = Actual360()
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 360
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 360
-    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 360
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == (4 + 366 + 365 + 365 + 365 + 58) / 360
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == (4 + 366 + 365 + 365 + 365 + 59) / 360
-    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == (4 + 366 + 365 + 365 + 365 + 60) / 360
-    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 360
-    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 360
-    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 360
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 360
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 360
+    @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 360
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == (4 + 366 + 365 + 365 + 365 + 58) / 360
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == (4 + 366 + 365 + 365 + 365 + 59) / 360
+    @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == (4 + 366 + 365 + 365 + 365 + 60) / 360
+    @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 360
+    @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 360
+    @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 360
 end
 
 @testset "ActualActualISDA" begin
     dc = ActualActualISDA()
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == 4 / 365 + 58 / 366
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == 4 / 365 + 59 / 366
-    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == 4 / 365 + 60 / 366
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == 4 / 365 + 58 / 366 + 4
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == 4 / 365 + 59 / 366 + 4
-    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == 4 / 365 + 60 / 366 + 4
-    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 366
-    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 366
-    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 366
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == 4 / 365 + 58 / 366
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == 4 / 365 + 59 / 366
+    @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == 4 / 365 + 60 / 366
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == 4 / 365 + 58 / 366 + 4
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == 4 / 365 + 59 / 366 + 4
+    @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == 4 / 365 + 60 / 366 + 4
+    @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 366
+    @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 366
+    @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 366
 end
 
 @testset "Thirty360" begin
     dc = Thirty360()
     # usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
-    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
-    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
-    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+    @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
 
-    @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((31-29) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,29), Date(2013, 8,31), dc) == ((31-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
 end
 
 @testset "ThirtyE360" begin
     dc = ThirtyE360()
     # usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
-    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
-    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
-    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
-    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+    @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
 
-    @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-    @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-    @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfrac(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfrac(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
 end
 
 @testset "ThirtyE360ISDA" begin
     @testset "maturity not end of Feb" begin
         dc = ThirtyE360ISDA(Date(2012, 8, 31))
-        @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((30-28) + (2-12)*30 + (2012-2011)*360)/360 # exception
-        @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((30-28) + (2-12)*30 + (2016-2011)*360)/360 # exception
-        @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
-        @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
-        @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-30) + (3-2)*30 + (2012-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((30-28) + (2-12)*30 + (2012-2011)*360)/360 # exception
+        @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == ((30-28) + (2-12)*30 + (2016-2011)*360)/360 # exception
+        @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+        @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+        @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-30) + (3-2)*30 + (2012-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
 
-        @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
     end
 
     @testset "maturity end of Feb" begin
         dc = ThirtyE360ISDA(Date(2012, 2,29)) # leap year, end of month
-        @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
-        @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((30-28) + (2-12)*30 + (2016-2011)*360)/360 # exception
-        @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
-        @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
-        @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-30) + (3-2)*30 + (2012-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+        @test yearfrac(Date(2011,12,28), Date(2016, 2,29), dc) == ((30-28) + (2-12)*30 + (2016-2011)*360)/360 # exception
+        @test yearfrac(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+        @test yearfrac(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+        @test yearfrac(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-30) + (3-2)*30 + (2012-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
 
-        @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-        @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
-        @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfrac(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfrac(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    end
+end
+
+
+@testset "ActuaActual ISDA Memo" begin
+    # these test cases are all derived from
+    # EMU and Market Conventions: Recent Developments, ISDA - BS:9951.1
+    # §4. The Actual/Actual Day Count Convention
+    # https://www.isda.org/a/AIJEE/1998-ISDA-memo-EMU-and-Market-Conventions-Recent-Developments.pdf
+    
+    @testset "short first" begin
+        dc_isda = ActualActualISDA()
+        dc_icma = ActualActualICMA(Date(1998,7,1):Month(12):Date(2000,7,1))
+
+        @test yearfrac(Date(1999,2,1), Date(1999,7,1), dc_isda) ≈ 0.41096 atol=0.000005
+        @test yearfrac(Date(1999,2,1), Date(1999,7,1), dc_icma) ≈ 0.41096 atol=0.000005
+
+        @test yearfrac(Date(1999,7,1), Date(2000,7,1), dc_isda) ≈ 1.00138 atol=0.000005
+        @test yearfrac(Date(1999,7,1), Date(2000,7,1), dc_icma) == 1.0
+
+        @test yearfrac(Date(1999,2,1), Date(2000,7,1), dc_isda) ≈ 0.41096 + 1.00138 atol=0.000005
+        @test yearfrac(Date(1999,2,1), Date(2000,7,1), dc_icma) ≈ 0.41096 + 1.0     atol=0.000005
+    end
+
+    @testset "long first" begin
+        dc_isda = ActualActualISDA()
+        dc_icma = ActualActualICMA(Date(2002,7,15):Month(6):Date(2004,1,15))
+
+        @test yearfrac(Date(2002,8,15), Date(2003,7,15), dc_isda) ≈ 0.91507 atol=0.000005
+        @test yearfrac(Date(2002,8,15), Date(2003,7,15), dc_icma) ≈ 0.91576 atol=0.000005
+
+        # This appears to be an error in the memo
+        # they calculate it as 184/365, but it should be 170/365 + 14/366?
+        # @test yearfrac(Date(2003,7,15),Date(2004,1,15), dc_isda) ≈ 0.50411 atol=0.000005
+        @test yearfrac(Date(2003,7,15), Date(2004,1,15), dc_icma) == 0.5
+
+        @test yearfrac(Date(2002,8,15), Date(2004,1,15), dc_icma) ≈ 0.91576 + 0.5 atol=0.000005
+    end
+
+    @testset "short final" begin
+        dc_isda = ActualActualISDA()        
+        dc_icma = ActualActualICMA(Date(1999,7,30):Month(6):Date(2000,7,30))
+
+        @test yearfrac(Date(1999,7,30), Date(2000,1,30), dc_isda) ≈ 0.50389 atol=0.000005
+        @test yearfrac(Date(1999,7,30), Date(2000,1,30), dc_icma) == 0.5
+
+        @test yearfrac(Date(2000,1,30), Date(2000,6,30), dc_isda) ≈ 0.41530 atol=0.000005
+        @test yearfrac(Date(2000,1,30), Date(2000,6,30), dc_icma) ≈ 0.41758 atol=0.000005
+
+        @test yearfrac(Date(1999,7,30), Date(2000,6,30), dc_isda) ≈ 0.50389 + 0.41530 atol=0.000005
+        @test yearfrac(Date(1999,7,30), Date(2000,6,30), dc_icma) ≈ 0.5     + 0.41758 atol=0.000005
+    end
+        
+    @testset "long final" begin
+        dc_isda = ActualActualISDA()
+        # TODO: need a way to express "last day of month" schedules.
+        dc_icma = ActualActualICMA(Date(1999,5,31):Month(3):Date(2000,5,31))
+
+        @test yearfrac(Date(1999,11,30), Date(2000,4,30), dc_isda) ≈ 0.41554 atol=0.000005
+        @test yearfrac(Date(1999,11,30), Date(2000,4,30), dc_icma) ≈ 0.41576 atol=0.000005
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,34 @@
-using DayCounts
+using DayCounts, Dates
 using Test
 
-# write your own tests here
-@test 1 == 1
+# based on tests from OpenGamma Strata
+# https://github.com/OpenGamma/Strata/blob/efaa0be0d08dc61c23692e7b86df101ea0fb7223/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual365Fixed()) == 62 / 365
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual365Fixed()) == 63 / 365
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual365Fixed()) == 64 / 365
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual365Fixed()) == (62 + 366 + 365 + 365 + 365) / 365
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual365Fixed()) == (63 + 366 + 365 + 365 + 365) / 365
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual365Fixed()) == (64 + 366 + 365 + 365 + 365) / 365
+@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Actual365Fixed()) == 29 / 365
+@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Actual365Fixed()) == 28 / 365
+@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Actual365Fixed()) == 27 / 365
+
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual360()) == 62 / 360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual360()) == 63 / 360
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual360()) == 64 / 360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual360()) == (62 + 366 + 365 + 365 + 365) / 360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual360()) == (63 + 366 + 365 + 365 + 365) / 360
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual360()) == (64 + 366 + 365 + 365 + 365) / 360
+@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Actual360()) == 29 / 360
+@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Actual360()) == 28 / 360
+@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Actual360()) == 27 / 360
+
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), ActualActualISDA()) == 4 / 365 + 58 / 366
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), ActualActualISDA()) == 4 / 365 + 59 / 366
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), ActualActualISDA()) == 4 / 365 + 60 / 366
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), ActualActualISDA()) == 4 / 365 + 58 / 366 + 4
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), ActualActualISDA()) == 4 / 365 + 59 / 366 + 4
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), ActualActualISDA()) == 4 / 365 + 60 / 366 + 4
+@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), ActualActualISDA()) == 29 / 366
+@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), ActualActualISDA()) == 28 / 366
+@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), ActualActualISDA()) == 27 / 366

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test
 # based on tests from OpenGamma Strata
 # https://github.com/OpenGamma/Strata/blob/efaa0be0d08dc61c23692e7b86df101ea0fb7223/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
 @testset "Actual365Fixed" begin
-    dc = Actual365Fixed()
+    dc = DayCounts.Actual365Fixed()
     @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 365
     @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 365
     @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 365
@@ -17,7 +17,7 @@ using Test
 end
 
 @testset "Actual360" begin
-    dc = Actual360()
+    dc = DayCounts.Actual360()
     @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 360
     @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 360
     @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 360
@@ -30,7 +30,7 @@ end
 end
 
 @testset "ActualActualISDA" begin
-    dc = ActualActualISDA()
+    dc = DayCounts.ActualActualISDA()
     @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == 4 / 365 + 58 / 366
     @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == 4 / 365 + 59 / 366
     @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == 4 / 365 + 60 / 366
@@ -43,7 +43,7 @@ end
 end
 
 @testset "Thirty360" begin
-    dc = Thirty360()
+    dc = DayCounts.Thirty360()
     # usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
     @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
     @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
@@ -67,7 +67,7 @@ end
 end
 
 @testset "ThirtyE360" begin
-    dc = ThirtyE360()
+    dc = DayCounts.ThirtyE360()
     # usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
     @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
     @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
@@ -92,7 +92,7 @@ end
 
 @testset "ThirtyE360ISDA" begin
     @testset "maturity not end of Feb" begin
-        dc = ThirtyE360ISDA(Date(2012, 8, 31))
+        dc = DayCounts.ThirtyE360ISDA(Date(2012, 8, 31))
         @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
         @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((30-28) + (2-12)*30 + (2012-2011)*360)/360 # exception
         @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
@@ -115,7 +115,7 @@ end
     end
 
     @testset "maturity end of Feb" begin
-        dc = ThirtyE360ISDA(Date(2012, 2,29)) # leap year, end of month
+        dc = DayCounts.ThirtyE360ISDA(Date(2012, 2,29)) # leap year, end of month
         @test yearfrac(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
         @test yearfrac(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
         @test yearfrac(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
@@ -146,8 +146,8 @@ end
     # https://www.isda.org/a/AIJEE/1998-ISDA-memo-EMU-and-Market-Conventions-Recent-Developments.pdf
     
     @testset "short first" begin
-        dc_isda = ActualActualISDA()
-        dc_icma = ActualActualICMA(Date(1998,7,1):Month(12):Date(2000,7,1))
+        dc_isda = DayCounts.ActualActualISDA()
+        dc_icma = DayCounts.ActualActualICMA(Date(1998,7,1):Month(12):Date(2000,7,1))
 
         @test yearfrac(Date(1999,2,1), Date(1999,7,1), dc_isda) ≈ 0.41096 atol=0.000005
         @test yearfrac(Date(1999,2,1), Date(1999,7,1), dc_icma) ≈ 0.41096 atol=0.000005
@@ -160,8 +160,8 @@ end
     end
 
     @testset "long first" begin
-        dc_isda = ActualActualISDA()
-        dc_icma = ActualActualICMA(Date(2002,7,15):Month(6):Date(2004,1,15))
+        dc_isda = DayCounts.ActualActualISDA()
+        dc_icma = DayCounts.ActualActualICMA(Date(2002,7,15):Month(6):Date(2004,1,15))
 
         @test yearfrac(Date(2002,8,15), Date(2003,7,15), dc_isda) ≈ 0.91507 atol=0.000005
         @test yearfrac(Date(2002,8,15), Date(2003,7,15), dc_icma) ≈ 0.91576 atol=0.000005
@@ -175,8 +175,8 @@ end
     end
 
     @testset "short final" begin
-        dc_isda = ActualActualISDA()        
-        dc_icma = ActualActualICMA(Date(1999,7,30):Month(6):Date(2000,7,30))
+        dc_isda = DayCounts.ActualActualISDA()        
+        dc_icma = DayCounts.ActualActualICMA(Date(1999,7,30):Month(6):Date(2000,7,30))
 
         @test yearfrac(Date(1999,7,30), Date(2000,1,30), dc_isda) ≈ 0.50389 atol=0.000005
         @test yearfrac(Date(1999,7,30), Date(2000,1,30), dc_icma) == 0.5
@@ -189,9 +189,9 @@ end
     end
         
     @testset "long final" begin
-        dc_isda = ActualActualISDA()
+        dc_isda = DayCounts.ActualActualISDA()
         # TODO: need a way to express "last day of month" schedules.
-        dc_icma = ActualActualICMA(Date(1999,5,31):Month(3):Date(2000,5,31))
+        dc_icma = DayCounts.ActualActualICMA(Date(1999,5,31):Month(3):Date(2000,5,31))
 
         @test yearfrac(Date(1999,11,30), Date(2000,4,30), dc_isda) ≈ 0.41554 atol=0.000005
         @test yearfrac(Date(1999,11,30), Date(2000,4,30), dc_icma) ≈ 0.41576 atol=0.000005

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,26 +3,29 @@ using Test
 
 # based on tests from OpenGamma Strata
 # https://github.com/OpenGamma/Strata/blob/efaa0be0d08dc61c23692e7b86df101ea0fb7223/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual365Fixed()) == 62 / 365
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual365Fixed()) == 63 / 365
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual365Fixed()) == 64 / 365
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual365Fixed()) == (62 + 366 + 365 + 365 + 365) / 365
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual365Fixed()) == (63 + 366 + 365 + 365 + 365) / 365
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual365Fixed()) == (64 + 366 + 365 + 365 + 365) / 365
+# Actual365Fixed
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual365Fixed()) == (4 + 58) / 365
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual365Fixed()) == (4 + 59) / 365
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual365Fixed()) == (4 + 60) / 365
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual365Fixed()) == (4 + 366 + 365 + 365 + 365 + 58) / 365
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual365Fixed()) == (4 + 366 + 365 + 365 + 365 + 59) / 365
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual365Fixed()) == (4 + 366 + 365 + 365 + 365 + 60) / 365
 @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Actual365Fixed()) == 29 / 365
 @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Actual365Fixed()) == 28 / 365
 @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Actual365Fixed()) == 27 / 365
 
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual360()) == 62 / 360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual360()) == 63 / 360
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual360()) == 64 / 360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual360()) == (62 + 366 + 365 + 365 + 365) / 360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual360()) == (63 + 366 + 365 + 365 + 365) / 360
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual360()) == (64 + 366 + 365 + 365 + 365) / 360
+# Actual360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual360()) == (4 + 58) / 360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual360()) == (4 + 59) / 360
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual360()) == (4 + 60) / 360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual360()) == (4 + 366 + 365 + 365 + 365 + 58) / 360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual360()) == (4 + 366 + 365 + 365 + 365 + 59) / 360
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual360()) == (4 + 366 + 365 + 365 + 365 + 60) / 360
 @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Actual360()) == 29 / 360
 @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Actual360()) == 28 / 360
 @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Actual360()) == 27 / 360
 
+# ActualActualISDA
 @test yearfraction(Date(2011,12,28), Date(2012, 2,28), ActualActualISDA()) == 4 / 365 + 58 / 366
 @test yearfraction(Date(2011,12,28), Date(2012, 2,29), ActualActualISDA()) == 4 / 365 + 59 / 366
 @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), ActualActualISDA()) == 4 / 365 + 60 / 366
@@ -32,3 +35,45 @@ using Test
 @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), ActualActualISDA()) == 29 / 366
 @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), ActualActualISDA()) == 28 / 366
 @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), ActualActualISDA()) == 27 / 366
+
+# Thirty360
+# usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Thirty360()) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Thirty360()) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Thirty360()) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Thirty360()) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Thirty360()) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Thirty360()) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Thirty360()) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Thirty360()) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
+@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Thirty360()) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+
+@test yearfraction(Date(2012, 5,30), Date(2013, 8,29), Thirty360()) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,29), Date(2013, 8,30), Thirty360()) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,30), Date(2013, 8,30), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,29), Date(2013, 8,31), Thirty360()) == ((31-29) + (8-5)*30 + (2013-2012)*360)/360
+# exceptions
+@test yearfraction(Date(2012, 5,30), Date(2013, 8,31), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,31), Date(2013, 8,30), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,31), Date(2013, 8,31), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+
+# ThirtyE360
+# usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,28), ThirtyE360()) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2012, 2,29), ThirtyE360()) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), ThirtyE360()) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,28), ThirtyE360()) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2016, 2,29), ThirtyE360()) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
+@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), ThirtyE360()) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), ThirtyE360()) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), ThirtyE360()) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
+@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), ThirtyE360()) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+
+@test yearfraction(Date(2012, 5,30), Date(2013, 8,29), ThirtyE360()) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,29), Date(2013, 8,30), ThirtyE360()) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,30), Date(2013, 8,30), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+# exceptions
+@test yearfraction(Date(2012, 5,29), Date(2013, 8,31), ThirtyE360()) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,30), Date(2013, 8,31), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,31), Date(2013, 8,30), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+@test yearfraction(Date(2012, 5,31), Date(2013, 8,31), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,77 +3,137 @@ using Test
 
 # based on tests from OpenGamma Strata
 # https://github.com/OpenGamma/Strata/blob/efaa0be0d08dc61c23692e7b86df101ea0fb7223/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
-# Actual365Fixed
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual365Fixed()) == (4 + 58) / 365
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual365Fixed()) == (4 + 59) / 365
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual365Fixed()) == (4 + 60) / 365
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual365Fixed()) == (4 + 366 + 365 + 365 + 365 + 58) / 365
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual365Fixed()) == (4 + 366 + 365 + 365 + 365 + 59) / 365
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual365Fixed()) == (4 + 366 + 365 + 365 + 365 + 60) / 365
-@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Actual365Fixed()) == 29 / 365
-@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Actual365Fixed()) == 28 / 365
-@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Actual365Fixed()) == 27 / 365
+@testset "Actual365Fixed" begin
+    dc = Actual365Fixed()
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 365
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 365
+    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 365
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == (4 + 366 + 365 + 365 + 365 + 58) / 365
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == (4 + 366 + 365 + 365 + 365 + 59) / 365
+    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == (4 + 366 + 365 + 365 + 365 + 60) / 365
+    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 365
+    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 365
+    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 365
+end
 
-# Actual360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Actual360()) == (4 + 58) / 360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Actual360()) == (4 + 59) / 360
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Actual360()) == (4 + 60) / 360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Actual360()) == (4 + 366 + 365 + 365 + 365 + 58) / 360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Actual360()) == (4 + 366 + 365 + 365 + 365 + 59) / 360
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Actual360()) == (4 + 366 + 365 + 365 + 365 + 60) / 360
-@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Actual360()) == 29 / 360
-@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Actual360()) == 28 / 360
-@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Actual360()) == 27 / 360
+@testset "Actual360" begin
+    dc = Actual360()
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == (4 + 58) / 360
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == (4 + 59) / 360
+    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == (4 + 60) / 360
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == (4 + 366 + 365 + 365 + 365 + 58) / 360
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == (4 + 366 + 365 + 365 + 365 + 59) / 360
+    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == (4 + 366 + 365 + 365 + 365 + 60) / 360
+    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 360
+    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 360
+    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 360
+end
 
-# ActualActualISDA
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), ActualActualISDA()) == 4 / 365 + 58 / 366
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), ActualActualISDA()) == 4 / 365 + 59 / 366
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), ActualActualISDA()) == 4 / 365 + 60 / 366
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), ActualActualISDA()) == 4 / 365 + 58 / 366 + 4
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), ActualActualISDA()) == 4 / 365 + 59 / 366 + 4
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), ActualActualISDA()) == 4 / 365 + 60 / 366 + 4
-@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), ActualActualISDA()) == 29 / 366
-@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), ActualActualISDA()) == 28 / 366
-@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), ActualActualISDA()) == 27 / 366
+@testset "ActualActualISDA" begin
+    dc = ActualActualISDA()
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == 4 / 365 + 58 / 366
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == 4 / 365 + 59 / 366
+    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == 4 / 365 + 60 / 366
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == 4 / 365 + 58 / 366 + 4
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == 4 / 365 + 59 / 366 + 4
+    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == 4 / 365 + 60 / 366 + 4
+    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == 29 / 366
+    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == 28 / 366
+    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == 27 / 366
+end
 
-# Thirty360
-# usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), Thirty360()) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), Thirty360()) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), Thirty360()) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), Thirty360()) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), Thirty360()) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), Thirty360()) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
-@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), Thirty360()) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
-@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), Thirty360()) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
-@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), Thirty360()) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+@testset "Thirty360" begin
+    dc = Thirty360()
+    # usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
 
-@test yearfraction(Date(2012, 5,30), Date(2013, 8,29), Thirty360()) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,29), Date(2013, 8,30), Thirty360()) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,30), Date(2013, 8,30), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,29), Date(2013, 8,31), Thirty360()) == ((31-29) + (8-5)*30 + (2013-2012)*360)/360
-# exceptions
-@test yearfraction(Date(2012, 5,30), Date(2013, 8,31), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,31), Date(2013, 8,30), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,31), Date(2013, 8,31), Thirty360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((31-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+end
 
-# ThirtyE360
-# usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,28), ThirtyE360()) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2012, 2,29), ThirtyE360()) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2012, 3, 1), ThirtyE360()) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,28), ThirtyE360()) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2016, 2,29), ThirtyE360()) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
-@test yearfraction(Date(2011,12,28), Date(2016, 3, 1), ThirtyE360()) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
-@test yearfraction(Date(2012, 2,28), Date(2012, 3,28), ThirtyE360()) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
-@test yearfraction(Date(2012, 2,29), Date(2012, 3,28), ThirtyE360()) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
-@test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), ThirtyE360()) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+@testset "ThirtyE360" begin
+    dc = ThirtyE360()
+    # usual rule: ((d2-d1) + (m2-m1)*30 + (y2-y1)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((29-28) + (2-12)*30 + (2016-2011)*360)/360
+    @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+    @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-29) + (3-2)*30 + (2012-2012)*360)/360
+    @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
 
-@test yearfraction(Date(2012, 5,30), Date(2013, 8,29), ThirtyE360()) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,29), Date(2013, 8,30), ThirtyE360()) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,30), Date(2013, 8,30), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-# exceptions
-@test yearfraction(Date(2012, 5,29), Date(2013, 8,31), ThirtyE360()) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,30), Date(2013, 8,31), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,31), Date(2013, 8,30), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
-@test yearfraction(Date(2012, 5,31), Date(2013, 8,31), ThirtyE360()) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+    @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+end
+
+@testset "ThirtyE360ISDA" begin
+    @testset "maturity not end of Feb" begin
+        dc = ThirtyE360ISDA(Date(2012, 8, 31))
+        @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((30-28) + (2-12)*30 + (2012-2011)*360)/360 # exception
+        @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((30-28) + (2-12)*30 + (2016-2011)*360)/360 # exception
+        @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+        @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+        @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-30) + (3-2)*30 + (2012-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+
+        @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    end
+
+    @testset "maturity end of Feb" begin
+        dc = ThirtyE360ISDA(Date(2012, 2,29)) # leap year, end of month
+        @test yearfraction(Date(2011,12,28), Date(2012, 2,28), dc) == ((28-28) + (2-12)*30 + (2012-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2012, 2,29), dc) == ((29-28) + (2-12)*30 + (2012-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2012, 3, 1), dc) == ((1-28) + (3-12)*30 + (2012-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2016, 2,28), dc) == ((28-28) + (2-12)*30 + (2016-2011)*360)/360
+        @test yearfraction(Date(2011,12,28), Date(2016, 2,29), dc) == ((30-28) + (2-12)*30 + (2016-2011)*360)/360 # exception
+        @test yearfraction(Date(2011,12,28), Date(2016, 3, 1), dc) == ((1-28) + (3-12)*30 + (2016-2011)*360)/360
+        @test yearfraction(Date(2012, 2,28), Date(2012, 3,28), dc) == ((28-28) + (3-2)*30 + (2012-2012)*360)/360
+        @test yearfraction(Date(2012, 2,29), Date(2012, 3,28), dc) == ((28-30) + (3-2)*30 + (2012-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 3, 1), Date(2012, 3,28), dc) == ((28-1) + (3-3)*30 + (2012-2012)*360)/360
+
+        @test yearfraction(Date(2012, 5,29), Date(2013, 8,29), dc) == ((29-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,29), Date(2013, 8,30), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,29), Date(2013, 8,31), dc) == ((30-29) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,30), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,30), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360
+        @test yearfraction(Date(2012, 5,30), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,31), Date(2013, 8,29), dc) == ((29-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,31), Date(2013, 8,30), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+        @test yearfraction(Date(2012, 5,31), Date(2013, 8,31), dc) == ((30-30) + (8-5)*30 + (2013-2012)*360)/360 # exception
+    end
+end


### PR DESCRIPTION
This allows `yearfraction` to have a consistent interface.
Also renamed `yearfrac` to `yearfraction`.